### PR TITLE
Fix for shell_out_with_systems_locale deprecation

### DIFF
--- a/resources/image.rb
+++ b/resources/image.rb
@@ -15,18 +15,18 @@ action_class do
   include CrioCookbook::Mixins::ResourceMethods
 
   def img_refs
-    cmd = shell_out_with_systems_locale!("#{podman_cmd} images --format '{{.Repository}}:{{.Tag}}'")
+    cmd = shell_out!("#{podman_cmd} images --format '{{.Repository}}:{{.Tag}}'", default_env: false)
     cmd.stdout.split("\n")
   end
 
   def img_shas
-    cmd = shell_out_with_systems_locale!("#{podman_cmd} images -q --no-trunc")
+    cmd = shell_out!("#{podman_cmd} images -q --no-trunc", default_env: false)
     cmd.stdout.split("\n")
   end
 
   def pull_img
     extant = img_shas
-    cmd = shell_out_with_systems_locale!("#{podman_cmd} pull -q #{new_resource.pull_opts} #{img_ref}", timeout: 3_600)
+    cmd = shell_out!("#{podman_cmd} pull -q #{new_resource.pull_opts} #{img_ref}", default_env: false, timeout: 3_600)
     !extant.any? { |img_sha| img_sha.end_with?(cmd.stdout.chomp) }
   end
 end


### PR DESCRIPTION
shell_out_with_systems_locale was removed from 'chef/mixin/shell_out' and the functionality rolled into shell_out:

[Deprecation warnings](https://github.com/chef/chef/commit/ccfe07dbd812890a732432bae7c2e522b79f643d#diff-f54e6ba45d43eee7cdc25838b79b012cR16)

[Removal for 15](https://github.com/chef/chef/commit/b2797d26679a1e6a2ca92e9785746ba1e12ea685#diff-705e34419cb662c524829ae3d0f22caa)

This fix runs fine in test-kitchen with (at least) recent 14 and 15 version clients.